### PR TITLE
fix/whitespaces-between-curly-brackets

### DIFF
--- a/src/angular/getChanges.ts
+++ b/src/angular/getChanges.ts
@@ -35,7 +35,7 @@ export const getChanges = (input: Input): Changes => {
 
 function getLiteralsTexts(literals: TemplateLiteral[]): Literal[] {
   return literals.flatMap((literal) =>
-    literal.matches.map((match) => ({ text: match.groups[0] }))
+    literal.matches.map((match) => ({ text: match.groups[0].trim() }))
   );
 }
 /**


### PR DESCRIPTION
Fix generated syntax errors if there are whitespaces inside the curly brackets:

```
<div>{{ dashboardName }}</div>
```

produces the following output:

```
<app-nav [ dashboardName ]=" dashboard "></app-nav>
```

The whitespaces are producing a syntax error in the generated output.