### PR TITLE
Fixes logPath for Windows

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -41,7 +41,7 @@ export function initLogger(
     extName: extensionId,
     level: logLevel,
     sourceLocationTracking: sourceLocationLogging,
-    logPath: context.logUri.toString(),
+    logPath: context.logUri.fsPath,
     logOutputChannel: createOutputChannel(extensionName),
     logConsole: true,
   }));


### PR DESCRIPTION
Fixes error with logger while running the extension on a Windows machine.

Error message showed this message directly after the extension was started:

```
Error while initializing logger Error: Path contains invalid characters: file:///c%3A/Users/philipp ...
```

By using `fsPath` instead of the toString method, this error could be resolved.